### PR TITLE
Create staged intro flow with scenario picker

### DIFF
--- a/components/session/ScenarioPicker.jsx
+++ b/components/session/ScenarioPicker.jsx
@@ -1,0 +1,114 @@
+export default function ScenarioPicker({
+  open,
+  onClose,
+  scenarios = [],
+  onSelect,
+  selectedScenarioId,
+}) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
+      <div
+        className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative z-10 w-full max-w-4xl overflow-hidden rounded-3xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">Scenario library</p>
+            <h3 className="text-lg font-semibold text-slate-900">Choose a scenario to practice</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1.5 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="max-h-[70vh] overflow-y-auto p-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {scenarios.map((scenario) => {
+              const isActive = scenario.id === selectedScenarioId;
+              return (
+                <button
+                  type="button"
+                  key={scenario.id}
+                  onClick={() => onSelect?.(scenario)}
+                  className={`group flex h-full flex-col justify-between rounded-2xl border p-5 text-left transition shadow-sm hover:-translate-y-1 hover:shadow-lg ${
+                    isActive
+                      ? 'border-indigo-500 bg-indigo-50 shadow-indigo-200/80'
+                      : 'border-slate-200 bg-white'
+                  }`}
+                >
+                  <div className="space-y-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <h4
+                        className={`text-lg font-semibold ${
+                          isActive ? 'text-indigo-900' : 'text-slate-900'
+                        }`}
+                      >
+                        {scenario.title}
+                      </h4>
+                      {isActive && (
+                        <span className="inline-flex items-center rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                          Selected
+                        </span>
+                      )}
+                    </div>
+                    {scenario.description && (
+                      <p
+                        className={`text-sm leading-relaxed ${
+                          isActive ? 'text-indigo-800/90' : 'text-slate-600'
+                        }`}
+                      >
+                        {scenario.description}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="mt-5 flex flex-wrap items-center gap-2 text-xs font-semibold">
+                    {scenario.difficulty && (
+                      <span
+                        className={`rounded-full px-3 py-1 ${
+                          isActive ? 'bg-white/80 text-indigo-700' : 'bg-indigo-50 text-indigo-600'
+                        }`}
+                      >
+                        {scenario.difficulty}
+                      </span>
+                    )}
+                    {scenario.duration && (
+                      <span
+                        className={`rounded-full px-3 py-1 ${
+                          isActive ? 'bg-white/60 text-indigo-700' : 'bg-slate-100 text-slate-600'
+                        }`}
+                      >
+                        {scenario.duration}
+                      </span>
+                    )}
+                    {scenario.focusAreas?.slice(0, 2).map((area) => (
+                      <span
+                        key={area}
+                        className={`rounded-full px-3 py-1 ${
+                          isActive ? 'bg-indigo-100 text-indigo-700' : 'bg-slate-100 text-slate-600'
+                        }`}
+                      >
+                        {area}
+                      </span>
+                    ))}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/session/ScenarioPreview.jsx
+++ b/components/session/ScenarioPreview.jsx
@@ -1,0 +1,72 @@
+const CHIP_BASE =
+  'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide';
+
+const VARIANT_STYLES = {
+  hero: {
+    container:
+      'rounded-3xl border border-white/20 bg-white/10 p-8 shadow-2xl shadow-indigo-950/40 backdrop-blur transition',
+    heading: 'text-3xl font-semibold text-white',
+    description: 'text-indigo-100',
+    chip: `${CHIP_BASE} bg-white/20 text-indigo-100`,
+    focusCard: 'rounded-2xl bg-white/12 p-4 text-sm text-indigo-100',
+    takeawaysWrapper:
+      'mt-6 rounded-2xl border border-white/20 bg-white/10 p-5 text-indigo-100/90 shadow-inner shadow-indigo-900/10',
+  },
+  panel: {
+    container:
+      'rounded-3xl border border-white/10 bg-slate-900/70 p-6 text-left shadow-xl shadow-indigo-950/30 transition',
+    heading: 'text-2xl font-semibold text-white',
+    description: 'text-slate-200',
+    chip: `${CHIP_BASE} bg-indigo-500/10 text-indigo-200`,
+    focusCard: 'rounded-2xl bg-slate-800/60 p-4 text-sm text-indigo-100',
+    takeawaysWrapper:
+      'mt-6 rounded-2xl border border-white/10 bg-slate-900/60 p-5 text-indigo-100/85 shadow-inner shadow-black/20',
+  },
+};
+
+export default function ScenarioPreview({ scenario, variant = 'panel' }) {
+  if (!scenario) {
+    return null;
+  }
+
+  const styles = VARIANT_STYLES[variant] || VARIANT_STYLES.panel;
+
+  return (
+    <article className={styles.container}>
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        {scenario.company && <span className={styles.chip}>{scenario.company}</span>}
+        {scenario.difficulty && <span className={styles.chip}>{scenario.difficulty}</span>}
+        {scenario.duration && <span className={styles.chip}>{scenario.duration}</span>}
+      </div>
+
+      <h2 className={`${styles.heading} mt-4`}>{scenario.title}</h2>
+      {scenario.description && (
+        <p className={`${styles.description} mt-3 text-base leading-relaxed`}>{scenario.description}</p>
+      )}
+
+      {scenario.focusAreas?.length > 0 && (
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          {scenario.focusAreas.map((area) => (
+            <div key={area} className={styles.focusCard}>
+              <span className="font-medium text-white/90">{area}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {scenario.takeaways?.length > 0 && (
+        <div className={styles.takeawaysWrapper}>
+          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-200">What to cover</p>
+          <ul className="mt-3 space-y-2 text-sm leading-relaxed">
+            {scenario.takeaways.map((item) => (
+              <li key={item} className="flex gap-2 text-indigo-100/90">
+                <span className="mt-1 h-1.5 w-1.5 flex-none rounded-full bg-indigo-300" aria-hidden />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce intro/session/summary stages on the home page with a start CTA and default scenario preview
- extract reusable scenario preview and picker components to support browsing interview templates
- restyle the session prompt area with Tailwind hero treatment instead of dropdown cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c9ebd44483279db51ed16ce46ccc