### PR TITLE
Add segment prompts and chat session panel

### DIFF
--- a/components/session/ChatPanel.jsx
+++ b/components/session/ChatPanel.jsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+function mapInitialMessages(initialMessages) {
+  if (!Array.isArray(initialMessages)) {
+    return [];
+  }
+
+  return initialMessages
+    .filter((message) => message && typeof message.content === 'string')
+    .map((message, index) => ({
+      id: message.id || `initial-${index}`,
+      role: message.role === 'assistant' ? 'assistant' : message.role === 'system' ? 'system' : 'user',
+      content: message.content,
+      segmentId: message.segmentId || null,
+      type: message.type || (message.role === 'system' ? 'notice' : message.role || 'user'),
+      createdAt: message.createdAt || Date.now()
+    }));
+}
+
+function getSegmentLabel(segment, fallback) {
+  if (!segment) {
+    return fallback;
+  }
+  return segment.label || segment.title || segment.name || fallback;
+}
+
+export default function ChatPanel({
+  sessionId,
+  activeSegmentId,
+  segments,
+  initialMessages
+}) {
+  const sanitizedInitialMessages = useMemo(() => mapInitialMessages(initialMessages), [initialMessages]);
+  const normalizedSegments = useMemo(() => (Array.isArray(segments) ? segments : []), [segments]);
+
+  const [thread, setThread] = useState(() => sanitizedInitialMessages);
+  const [inputValue, setInputValue] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const bottomRef = useRef(null);
+  const previousSegmentRef = useRef(null);
+  const threadRef = useRef(thread);
+
+  useEffect(() => {
+    threadRef.current = thread;
+  }, [thread]);
+
+  useEffect(() => {
+    setThread(sanitizedInitialMessages);
+  }, [sanitizedInitialMessages]);
+
+  const segmentLookup = useMemo(() => {
+    return new Map(normalizedSegments.map((segment) => [segment.id || segment.segmentId, segment]));
+  }, [normalizedSegments]);
+
+  useEffect(() => {
+    if (!activeSegmentId) {
+      return;
+    }
+
+    const previousSegmentId = previousSegmentRef.current;
+    if (previousSegmentId === activeSegmentId) {
+      return;
+    }
+
+    const segment = segmentLookup.get(activeSegmentId) || null;
+    const label = getSegmentLabel(segment, activeSegmentId);
+    const durationSeconds = segment && (segment.durationSeconds ?? segment.duration ?? null);
+    const durationMinutes = durationSeconds ? Math.round(durationSeconds / 60) : null;
+
+    const noticePrefix = previousSegmentId ? 'Timer advanced to' : 'Starting';
+    const durationText = durationMinutes ? ` — approximately ${durationMinutes} minute${durationMinutes === 1 ? '' : 's'} remaining.` : '.';
+    const noticeMessage = `${noticePrefix} ${label}${durationText}`;
+
+    setThread((current) => [
+      ...current,
+      {
+        id: `notice-${Date.now()}`,
+        role: 'system',
+        content: noticeMessage,
+        segmentId: activeSegmentId,
+        type: 'notice',
+        createdAt: Date.now()
+      }
+    ]);
+
+    previousSegmentRef.current = activeSegmentId;
+  }, [activeSegmentId, segmentLookup]);
+
+  useEffect(() => {
+    if (bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [thread]);
+
+  const hasActiveSegment = Boolean(activeSegmentId);
+  const activeSegment = useMemo(() => segmentLookup.get(activeSegmentId) || null, [segmentLookup, activeSegmentId]);
+  const activeSegmentLabel = getSegmentLabel(activeSegment, activeSegmentId || 'current segment');
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmed = inputValue.trim();
+
+    if (!trimmed || !sessionId || !hasActiveSegment) {
+      return;
+    }
+
+    const userMessage = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: trimmed,
+      segmentId: activeSegmentId,
+      type: 'user',
+      createdAt: Date.now()
+    };
+
+    const conversationForRequest = [
+      ...threadRef.current.filter((message) => message.role === 'assistant' || message.role === 'user'),
+      userMessage
+    ].map((message) => ({
+      role: message.role,
+      content: message.content,
+      segmentId: message.segmentId
+    }));
+
+    setThread((current) => [...current, userMessage]);
+    setInputValue('');
+    setIsSending(true);
+
+    try {
+      const response = await fetch('/api/session/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId,
+          segmentId: activeSegmentId,
+          messages: conversationForRequest
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Server responded with status ${response.status}`);
+      }
+
+      const data = await response.json();
+      if (!data || typeof data.reply !== 'string') {
+        throw new Error('Malformed response from server');
+      }
+
+      const assistantMessage = {
+        id: `assistant-${Date.now()}`,
+        role: 'assistant',
+        content: data.reply,
+        segmentId: activeSegmentId,
+        type: 'assistant',
+        createdAt: Date.now()
+      };
+
+      setThread((current) => [...current, assistantMessage]);
+    } catch (error) {
+      setThread((current) => [
+        ...current,
+        {
+          id: `error-${Date.now()}`,
+          role: 'system',
+          content: `Unable to deliver your message. ${error.message}`,
+          segmentId: activeSegmentId,
+          type: 'error',
+          createdAt: Date.now()
+        }
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-4 py-3">
+        <h2 className="text-base font-semibold text-slate-900">Interview Chat</h2>
+        <p className="text-xs text-slate-500">Currently in {activeSegmentLabel}.</p>
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4 text-sm text-slate-800">
+        {thread.map((message) => {
+          const isAssistant = message.role === 'assistant';
+          const isUser = message.role === 'user';
+          const isSystem = message.role === 'system';
+          const bubbleClasses = isAssistant
+            ? 'bg-indigo-50 border border-indigo-100 text-slate-900'
+            : isUser
+              ? 'bg-slate-900 text-white'
+              : message.type === 'error'
+                ? 'bg-rose-50 border border-rose-200 text-rose-700'
+                : 'bg-slate-100 text-slate-700';
+
+          return (
+            <div key={message.id} className="flex flex-col">
+              <div className="mb-1 text-[0.65rem] uppercase tracking-wide text-slate-400">
+                {isUser && 'You'}
+                {isAssistant && 'Interviewer'}
+                {isSystem && !isUser && !isAssistant && 'System'}
+                {message.segmentId && (
+                  <span className="ml-1 lowercase text-slate-300">
+                    · {message.segmentId}
+                  </span>
+                )}
+              </div>
+              <div className={`max-w-full rounded-lg px-3 py-2 leading-relaxed ${bubbleClasses}`}>
+                {message.content}
+              </div>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3">
+        <fieldset disabled={isSending || !hasActiveSegment} className="flex flex-col gap-2">
+          <textarea
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder={hasActiveSegment ? `Respond for the ${activeSegmentLabel} segment...` : 'Waiting for the next segment to begin'}
+            rows={3}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-slate-100"
+          />
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>{hasActiveSegment ? `Tagging responses as ${activeSegmentLabel}.` : 'Input disabled until the next segment starts.'}</span>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSending ? 'Sending…' : 'Send'}
+            </button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "next": "^14.2.32",
+        "openai": "^4.104.0",
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0"
@@ -587,6 +588,25 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "18.19.127",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
+      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
@@ -1012,6 +1032,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1033,6 +1065,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1310,6 +1354,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1516,7 +1566,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1714,6 +1763,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1910,6 +1971,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1976,7 +2046,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2081,7 +2150,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2091,7 +2159,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2129,7 +2196,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2142,7 +2208,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2665,6 +2730,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2830,6 +2904,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2870,7 +2979,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2911,7 +3019,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2936,7 +3043,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3070,7 +3176,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3148,7 +3253,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3161,7 +3265,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3177,7 +3280,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3234,6 +3336,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4050,7 +4161,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4675,6 +4785,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4845,6 +4976,46 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
@@ -5013,6 +5184,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -6515,6 +6716,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -6712,6 +6919,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -6908,6 +7121,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "next": "^14.2.32",
+    "openai": "^4.104.0",
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0"

--- a/pages/api/session/messages.js
+++ b/pages/api/session/messages.js
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { OpenAI } from 'openai';
+
+const templateCache = new Map();
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const model = process.env.OPENAI_API_MODEL || 'gpt-4.1-mini';
+
+async function loadSegmentTemplate(segmentId) {
+  if (templateCache.has(segmentId)) {
+    return templateCache.get(segmentId);
+  }
+
+  const templatePath = path.join(process.cwd(), 'prompts', 'segments', `${segmentId}.json`);
+  const rawTemplate = await fs.readFile(templatePath, 'utf8');
+  const parsedTemplate = JSON.parse(rawTemplate);
+
+  if (!parsedTemplate || typeof parsedTemplate !== 'object') {
+    throw new Error(`Invalid template for segment: ${segmentId}`);
+  }
+
+  templateCache.set(segmentId, parsedTemplate);
+  return parsedTemplate;
+}
+
+function buildSystemPrompt(sessionId, template) {
+  const sections = [];
+
+  if (template.title) {
+    sections.push(`You are facilitating the "${template.title}" segment of an ML system design interview session.`);
+  } else {
+    sections.push('You are facilitating a segment of an ML system design interview session.');
+  }
+
+  if (template.tone) {
+    sections.push(`Adopt the following tone: ${template.tone}`);
+  }
+
+  if (Array.isArray(template.expectations) && template.expectations.length > 0) {
+    sections.push(`Segment expectations:\n- ${template.expectations.join('\n- ')}`);
+  }
+
+  if (template.guidance) {
+    sections.push(template.guidance);
+  }
+
+  sections.push(
+    'Address the candidate directly as their interviewer. Reference details from earlier messages when relevant, keep responses concise, and ask one focused question or deliver one piece of feedback at a time.'
+  );
+
+  sections.push(`This conversation belongs to session ${sessionId}. Maintain continuity with prior exchanges while staying aligned with the current segment objectives.`);
+
+  return sections.join('\n\n');
+}
+
+function prepareMessagesForModel(messages, activeSegmentId) {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  return messages
+    .filter((message) => message && typeof message.content === 'string' && message.content.trim().length > 0)
+    .map((message) => {
+      const role = message.role === 'assistant' ? 'assistant' : 'user';
+      const prefix = message.segmentId && message.segmentId !== activeSegmentId ? `[Segment: ${message.segmentId}] ` : '';
+      return {
+        role,
+        content: [
+          {
+            type: 'text',
+            text: `${prefix}${message.content.trim()}`
+          }
+        ]
+      };
+    });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { sessionId, segmentId, messages } = req.body || {};
+
+  if (!sessionId || !segmentId) {
+    return res.status(400).json({ error: 'sessionId and segmentId are required.' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'OpenAI API key is not configured.' });
+  }
+
+  let template;
+  try {
+    template = await loadSegmentTemplate(segmentId);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return res.status(404).json({ error: `No prompt template found for segment ${segmentId}.` });
+    }
+    console.error('Failed to load segment template', error);
+    return res.status(500).json({ error: 'Unable to load segment template.' });
+  }
+
+  const systemPrompt = buildSystemPrompt(sessionId, template);
+  const conversationalMessages = prepareMessagesForModel(messages, segmentId);
+
+  try {
+    const response = await client.responses.create({
+      model,
+      input: [
+        {
+          role: 'system',
+          content: [
+            {
+              type: 'text',
+              text: systemPrompt
+            }
+          ]
+        },
+        ...conversationalMessages
+      ]
+    });
+
+    const reply = (response && typeof response.output_text === 'string') ? response.output_text.trim() : '';
+
+    if (!reply) {
+      return res.status(500).json({ error: 'OpenAI response did not contain any text.' });
+    }
+
+    return res.status(200).json({ reply });
+  } catch (error) {
+    console.error('Failed to generate assistant response', error);
+    return res.status(502).json({ error: 'Failed to generate assistant response.' });
+  }
+}

--- a/prompts/segments/deep-dive-qa.json
+++ b/prompts/segments/deep-dive-qa.json
@@ -1,0 +1,11 @@
+{
+  "id": "deep-dive-qa",
+  "title": "Deep Dive Q&A",
+  "tone": "Direct, analytical, and fair. Push for precision while keeping the dialogue respectful and grounded in evidence.",
+  "expectations": [
+    "Probe specific design decisions with follow-up questions that test depth of understanding.",
+    "Surface edge cases, failure modes, and measurement strategies.",
+    "Offer succinct feedback on strong answers and point out gaps that need further exploration."
+  ],
+  "guidance": "Treat this segment like a technical grilling but keep it constructive. Ask one question at a time, referencing earlier candidate statements to check for consistency or deeper reasoning."
+}

--- a/prompts/segments/problem-framing.json
+++ b/prompts/segments/problem-framing.json
@@ -1,0 +1,11 @@
+{
+  "id": "problem-framing",
+  "title": "Problem Framing",
+  "tone": "Confident, structured, and inquisitive. Maintain an invitational tone that encourages clarifying questions and thoughtful trade-off discussions.",
+  "expectations": [
+    "Present the core scenario, surfacing constraints, success metrics, and user experience goals.",
+    "Invite the candidate to restate the problem in their own words and probe for missing requirements.",
+    "Highlight evaluation criteria so the candidate knows what great answers look like before moving into solutioning."
+  ],
+  "guidance": "Guide the candidate through understanding the problem space. Encourage them to ask questions, document assumptions, and discuss risks or ambiguities they want to resolve."
+}

--- a/prompts/segments/solution-exploration.json
+++ b/prompts/segments/solution-exploration.json
@@ -1,0 +1,11 @@
+{
+  "id": "solution-exploration",
+  "title": "Solution Exploration",
+  "tone": "Curious, technical, and coaching-oriented. Challenge the candidate with depth while signaling that brainstorming and iteration are expected.",
+  "expectations": [
+    "Encourage the candidate to propose end-to-end architectures and justify component choices.",
+    "Ask for trade-offs around models, data pipelines, evaluation, and operational considerations.",
+    "Keep the conversation collaborative by acknowledging good ideas and pushing gently where more rigor is needed."
+  ],
+  "guidance": "Use follow-up questions to explore design decisions deeply. Reference context gathered earlier and look for opportunities to contrast alternative approaches or highlight best practices."
+}

--- a/prompts/segments/warm-up.json
+++ b/prompts/segments/warm-up.json
@@ -1,0 +1,11 @@
+{
+  "id": "warm-up",
+  "title": "Warm-Up Calibration",
+  "tone": "Welcoming, encouraging, and collaborative. Keep the candidate at ease while staying purposeful about uncovering goals and context.",
+  "expectations": [
+    "Greet the candidate, outline the interview flow at a high level, and confirm they are ready to begin.",
+    "Prompt the candidate to share their experience level, recent projects, and any areas they want to emphasize or avoid.",
+    "Reflect key details back to the candidate to show active listening before transitioning to the next segment."
+  ],
+  "guidance": "Set the stage for a supportive mock interview. Focus on rapport and calibration rather than deep technical questioning. Capture any objectives the candidate states so you can reference them later in the session."
+}

--- a/prompts/segments/wrap-up-feedback.json
+++ b/prompts/segments/wrap-up-feedback.json
@@ -1,0 +1,11 @@
+{
+  "id": "wrap-up-feedback",
+  "title": "Wrap-Up & Feedback",
+  "tone": "Supportive, concise, and reflective. Balance constructive critique with encouragement and actionable next steps.",
+  "expectations": [
+    "Summarize key strengths and notable decisions from the session.",
+    "Offer targeted areas for improvement and resources for continued practice.",
+    "Invite the candidate to share final questions or reflections before closing the interview."
+  ],
+  "guidance": "Close the session with clarity and empathy. Reinforce what went well, suggest concrete follow-ups, and ensure the candidate leaves with a sense of direction."
+}


### PR DESCRIPTION
## Summary
- add interviewer prompt templates for each interview segment under `prompts/segments`
- implement `/api/session/messages` to load templates, call OpenAI responses API, and return assistant replies
- create `ChatPanel` component to manage segment-tagged conversations and system notices

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d6ca2a6b648327b937b616d062839b