### PR TITLE
Add session wrap-up summary and persistence flow

### DIFF
--- a/components/session/SummaryScreen.jsx
+++ b/components/session/SummaryScreen.jsx
@@ -1,0 +1,242 @@
+import { useMemo } from 'react';
+
+function formatDuration(ms) {
+  if (!ms && ms !== 0) return '—';
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value) => value.toString().padStart(2, '0');
+  return `${minutes}:${pad(seconds)}`;
+}
+
+function buildMarkdown(summary) {
+  const lines = [];
+  lines.push(`# Session Summary`);
+  lines.push('');
+  lines.push(`- **Session ID:** ${summary.sessionId}`);
+  if (summary.scenarioId) {
+    lines.push(`- **Scenario:** ${summary.scenarioId}`);
+  }
+  lines.push(`- **Status:** ${summary.status}`);
+  if (summary.exitReason) {
+    lines.push(`- **Exit Reason:** ${summary.exitReason}`);
+  }
+  lines.push(`- **Started:** ${summary.startedAt || 'Unknown'}`);
+  lines.push(`- **Ended:** ${summary.endedAt || 'Unknown'}`);
+  if (summary.totalDurationMs != null) {
+    lines.push(`- **Total Duration:** ${formatDuration(summary.totalDurationMs)}`);
+  }
+  lines.push(`- **Messages:** ${summary.messageCount ?? summary.chatLog?.length ?? 0}`);
+  lines.push('');
+
+  if (summary.timing?.segments?.length) {
+    lines.push('## Segment Timings');
+    lines.push('');
+    lines.push('| Segment | Planned | Actual | Status |');
+    lines.push('| --- | --- | --- | --- |');
+    summary.timing.segments.forEach((segment, index) => {
+      lines.push(`| ${segment.name || `Segment ${index + 1}`} | ${formatDuration(segment.plannedDurationMs)} | ${formatDuration(segment.elapsedMs)} | ${segment.status || '—'} |`);
+    });
+    lines.push('');
+  }
+
+  if (summary.chatLog?.length) {
+    lines.push('## Chat Log');
+    lines.push('');
+    summary.chatLog.forEach((message, index) => {
+      lines.push(`### ${index + 1}. ${message.role || 'participant'} — ${message.timestamp || ''}`);
+      lines.push('');
+      lines.push(message.content || '');
+      lines.push('');
+    });
+  }
+
+  if (summary.takeaways?.length) {
+    lines.push('## Key Takeaways');
+    lines.push('');
+    summary.takeaways.forEach((item) => {
+      lines.push(`- ${item}`);
+    });
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export default function SummaryScreen({ summary, onRestart, onChangeScenario, isPersisting = false, persistenceError = null }) {
+  const takeaways = useMemo(() => {
+    if (summary?.takeaways?.length) return summary.takeaways;
+    if (!summary?.chatLog?.length) {
+      return [
+        'Session completed without recorded feedback. Review the conversation log to capture follow-up actions.',
+      ];
+    }
+    const coachMessages = summary.chatLog.filter((entry) => entry.role === 'coach' || entry.metadata?.category === 'takeaway');
+    if (coachMessages.length) {
+      return coachMessages.slice(-3).map((entry) => entry.content);
+    }
+    return [
+      'Reflect on pacing across segments and plan improvements for the next run.',
+      'Review any flagged timestamps in the transcript for deeper analysis.',
+    ];
+  }, [summary]);
+
+  const downloadMarkdown = () => {
+    if (!summary) return;
+    const blob = new Blob([buildMarkdown(summary)], { type: 'text/markdown' });
+    triggerDownload(blob, `${summary.sessionId || 'session'}-summary.md`);
+  };
+
+  const downloadJson = () => {
+    if (!summary) return;
+    const blob = new Blob([JSON.stringify(summary, null, 2)], { type: 'application/json' });
+    triggerDownload(blob, `${summary.sessionId || 'session'}-summary.json`);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto bg-white rounded-2xl shadow-xl border border-gray-200 p-8 space-y-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-900">Session wrap-up</h2>
+          <p className="text-gray-600 mt-1">
+            {summary.status === 'completed'
+              ? 'Great job! Here’s a recap of the conversation and timing insights.'
+              : 'Session ended early. Review the transcript and plan your next attempt.'}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={downloadMarkdown}
+            className="px-4 py-2 text-sm font-medium text-purple-600 bg-purple-50 hover:bg-purple-100 rounded-lg border border-purple-200"
+          >
+            Download Markdown
+          </button>
+          <button
+            type="button"
+            onClick={downloadJson}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg border border-gray-300"
+          >
+            Download JSON
+          </button>
+        </div>
+      </div>
+
+      {persistenceError && (
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 text-sm">
+          {persistenceError}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <SummaryStat label="Status" value={summary.status === 'completed' ? 'Completed' : 'Exited early'} />
+        <SummaryStat label="Total duration" value={formatDuration(summary.totalDurationMs)} />
+        <SummaryStat label="Messages" value={summary.messageCount ?? summary.chatLog?.length ?? 0} />
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-gray-900">Key takeaways</h3>
+        <ul className="list-disc list-inside space-y-2 text-gray-700">
+          {takeaways.map((item, index) => (
+            <li key={`takeaway-${index}`}>{item}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900">Segment timings</h3>
+        <div className="overflow-hidden rounded-xl border border-gray-200">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-gray-600">Segment</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-gray-600">Planned</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-gray-600">Actual</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium text-gray-600">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {summary.timing?.segments?.map((segment, index) => (
+                <tr key={segment.id || index}>
+                  <td className="px-4 py-3 font-medium text-gray-900">{segment.name || `Segment ${index + 1}`}</td>
+                  <td className="px-4 py-3 text-gray-600">{formatDuration(segment.plannedDurationMs)}</td>
+                  <td className="px-4 py-3 text-gray-600">{formatDuration(segment.elapsedMs)}</td>
+                  <td className="px-4 py-3">
+                    <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-purple-50 text-purple-700">
+                      {segment.status || '—'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-gray-900">Transcript preview</h3>
+        <div className="max-h-72 overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
+          {summary.chatLog?.length ? (
+            summary.chatLog.map((message, index) => (
+              <div key={message.id || index} className="bg-white rounded-lg border border-gray-200 p-3 shadow-sm">
+                <div className="flex items-center justify-between text-xs text-gray-500 mb-2">
+                  <span className="font-medium text-gray-700 uppercase tracking-wide">{message.role || 'participant'}</span>
+                  <span>{message.timestamp ? new Date(message.timestamp).toLocaleString() : '—'}</span>
+                </div>
+                <p className="text-sm text-gray-800 whitespace-pre-wrap">{message.content}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-gray-600">No messages recorded for this session.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 pt-4 border-t border-gray-200">
+        <div className="text-sm text-gray-500">
+          {isPersisting
+            ? 'Saving transcript to your workspace…'
+            : persistenceError
+              ? 'Transcript could not be saved automatically. Download the summary to keep a copy.'
+              : 'Transcript saved to your workspace.'}
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onRestart}
+            className="px-4 py-2 text-sm font-semibold text-white bg-purple-600 hover:bg-purple-700 rounded-lg shadow"
+          >
+            Run again
+          </button>
+          <button
+            type="button"
+            onClick={onChangeScenario}
+            className="px-4 py-2 text-sm font-medium text-purple-600 bg-purple-50 hover:bg-purple-100 rounded-lg border border-purple-200"
+          >
+            Change scenario
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function SummaryStat({ label, value }) {
+  return (
+    <div className="bg-gray-50 rounded-xl border border-gray-200 p-4">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="mt-1 text-xl font-semibold text-gray-900">{value ?? '—'}</div>
+    </div>
+  );
+}

--- a/lib/session/controller.js
+++ b/lib/session/controller.js
@@ -1,0 +1,324 @@
+const createId = () => `sess-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+
+function now() {
+  return new Date();
+}
+
+function iso(date) {
+  if (!date) return null;
+  return date instanceof Date ? date.toISOString() : new Date(date).toISOString();
+}
+
+function clone(obj) {
+  if (obj === null || obj === undefined) return obj;
+  return JSON.parse(JSON.stringify(obj));
+}
+
+export class SessionController {
+  constructor({ sessionId, scenarioId, segments = [], metadata = {} } = {}) {
+    this.sessionId = sessionId || createId();
+    this.scenarioId = scenarioId || null;
+    this.metadata = metadata;
+
+    this._handlers = new Map();
+    this._state = 'idle';
+    this._startedAt = null;
+    this._endedAt = null;
+    this._exitReason = null;
+    this._chatLog = [];
+    this._summary = null;
+
+    this._segments = segments.map((segment, index) => {
+      const normalized = typeof segment === 'number'
+        ? { durationSeconds: segment }
+        : segment || {};
+
+      const plannedMs = normalized.durationMs
+        || (normalized.durationSeconds != null ? normalized.durationSeconds * 1000 : null);
+
+      return {
+        id: normalized.id || `segment-${index + 1}`,
+        name: normalized.name || `Segment ${index + 1}`,
+        plannedDurationMs: plannedMs,
+        startedAt: null,
+        endedAt: null,
+        elapsedMs: 0,
+        status: 'pending',
+        meta: normalized.meta || {},
+        _activeTimestamp: null,
+      };
+    });
+
+    this._currentSegmentIndex = -1;
+  }
+
+  /** Register a listener for a specific event. */
+  on(eventName, handler) {
+    if (!this._handlers.has(eventName)) {
+      this._handlers.set(eventName, new Set());
+    }
+    this._handlers.get(eventName).add(handler);
+    return () => this.off(eventName, handler);
+  }
+
+  /** Remove an event listener. */
+  off(eventName, handler) {
+    const handlers = this._handlers.get(eventName);
+    if (!handlers) return;
+    handlers.delete(handler);
+    if (handlers.size === 0) {
+      this._handlers.delete(eventName);
+    }
+  }
+
+  /** Remove all listeners for an event or the entire controller. */
+  removeAllListeners(eventName) {
+    if (eventName) {
+      this._handlers.delete(eventName);
+      return;
+    }
+    this._handlers.clear();
+  }
+
+  _emit(eventName, payload) {
+    const handlers = this._handlers.get(eventName);
+    if (!handlers) return;
+    handlers.forEach((handler) => {
+      try {
+        handler(payload);
+      } catch (error) {
+        console.error(`SessionController handler for "${eventName}" failed`, error);
+      }
+    });
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  get chatLog() {
+    return [...this._chatLog];
+  }
+
+  get segments() {
+    return this._segments.map((segment) => ({
+      id: segment.id,
+      name: segment.name,
+      plannedDurationMs: segment.plannedDurationMs,
+      startedAt: segment.startedAt,
+      endedAt: segment.endedAt,
+      elapsedMs: segment.elapsedMs,
+      status: segment.status,
+      meta: clone(segment.meta),
+    }));
+  }
+
+  begin() {
+    if (this._state !== 'idle') {
+      return;
+    }
+    this._startedAt = now();
+    this._state = 'running';
+    this._emit('session:start', {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+      startedAt: iso(this._startedAt),
+      metadata: clone(this.metadata),
+    });
+  }
+
+  /**
+   * Move to the next segment in the configured flow. Automatically completes any
+   * currently active segment.
+   */
+  advance() {
+    if (this._state !== 'running') return null;
+
+    if (this._currentSegmentIndex >= 0) {
+      const active = this._segments[this._currentSegmentIndex];
+      if (active && active.status === 'in-progress') {
+        this._completeCurrentSegmentInternal('completed');
+      }
+    }
+
+    const nextIndex = this._currentSegmentIndex + 1;
+    if (nextIndex >= this._segments.length) {
+      this.finish();
+      return null;
+    }
+
+    this._currentSegmentIndex = nextIndex;
+    const segment = this._segments[this._currentSegmentIndex];
+    if (!segment.startedAt) {
+      const timestamp = now();
+      segment.startedAt = iso(timestamp);
+      segment._activeTimestamp = timestamp.getTime();
+      segment.status = 'in-progress';
+    }
+    this._emit('segment:start', {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+      segment: this._serializeSegment(segment),
+      index: this._currentSegmentIndex,
+    });
+    return this._serializeSegment(segment);
+  }
+
+  /** Mark the current segment as completed and optionally move to the next. */
+  completeCurrentSegment({ status = 'completed', advance = true } = {}) {
+    if (this._state !== 'running') return null;
+    const segment = this._completeCurrentSegmentInternal(status);
+    if (!segment) return null;
+    if (advance) {
+      this.advance();
+    }
+    return segment;
+  }
+
+  _completeCurrentSegmentInternal(status) {
+    if (this._currentSegmentIndex < 0 || this._currentSegmentIndex >= this._segments.length) {
+      return null;
+    }
+    const segment = this._segments[this._currentSegmentIndex];
+    const endTime = now();
+    if (!segment.startedAt) {
+      segment.startedAt = iso(endTime);
+    }
+    if (segment._activeTimestamp) {
+      segment.elapsedMs += Math.max(0, endTime.getTime() - segment._activeTimestamp);
+    }
+    segment._activeTimestamp = null;
+    segment.endedAt = iso(endTime);
+    segment.status = status;
+
+    const payload = {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+      segment: this._serializeSegment(segment),
+      index: this._currentSegmentIndex,
+    };
+    this._emit('segment:end', payload);
+    return payload.segment;
+  }
+
+  /** Append a message to the session chat log. */
+  recordMessage({ role, content, metadata = {} }) {
+    if (!role || !content) {
+      throw new Error('role and content are required to record a message.');
+    }
+    const timestamp = iso(now());
+    const entry = {
+      id: metadata.id || `msg-${this._chatLog.length + 1}`,
+      role,
+      content,
+      timestamp,
+      metadata: clone(metadata),
+    };
+    this._chatLog.push(entry);
+    this._emit('chat:message', {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+      message: entry,
+    });
+    return entry;
+  }
+
+  /** Finish the session normally and emit a summary payload. */
+  finish() {
+    if (this._state === 'completed' || this._state === 'aborted') {
+      return this._summary;
+    }
+    if (this._state === 'running') {
+      this._completeCurrentSegmentInternal('completed');
+    }
+    this._state = 'completed';
+    this._endedAt = now();
+    const summary = this._buildSummary('completed');
+    this._summary = summary;
+    this._emit('summary', summary);
+    this._emit('session:finished', summary);
+    return summary;
+  }
+
+  /** Exit the session early with a reason and emit a summary payload. */
+  exitEarly(reason = 'interrupted') {
+    if (this._state === 'completed' || this._state === 'aborted') {
+      return this._summary;
+    }
+    if (this._state === 'running') {
+      this._completeCurrentSegmentInternal('interrupted');
+    }
+    this._state = 'aborted';
+    this._exitReason = reason;
+    this._endedAt = now();
+    const summary = this._buildSummary('aborted');
+    this._summary = summary;
+    this._emit('summary', summary);
+    this._emit('session:finished', summary);
+    return summary;
+  }
+
+  _serializeSegment(segment) {
+    return {
+      id: segment.id,
+      name: segment.name,
+      plannedDurationMs: segment.plannedDurationMs,
+      startedAt: segment.startedAt,
+      endedAt: segment.endedAt,
+      elapsedMs: segment.elapsedMs,
+      status: segment.status,
+      meta: clone(segment.meta),
+    };
+  }
+
+  _buildSummary(status) {
+    const completedAt = this._endedAt || now();
+    const segments = this._segments.map((segment) => this._serializeSegment(segment));
+    const totalElapsedMs = segments.reduce((sum, segment) => sum + (segment.elapsedMs || 0), 0);
+    const totalPlannedMs = segments.reduce((sum, segment) => sum + (segment.plannedDurationMs || 0), 0);
+
+    const summary = {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+      status,
+      exitReason: status === 'aborted' ? this._exitReason : null,
+      startedAt: iso(this._startedAt),
+      endedAt: iso(completedAt),
+      totalDurationMs: this._startedAt ? completedAt.getTime() - this._startedAt.getTime() : totalElapsedMs,
+      timing: {
+        segments,
+        totalElapsedMs,
+        totalPlannedMs,
+      },
+      chatLog: this.chatLog,
+      messageCount: this._chatLog.length,
+      metadata: clone(this.metadata),
+      generatedAt: iso(now()),
+    };
+
+    return summary;
+  }
+
+  reset() {
+    this._state = 'idle';
+    this._startedAt = null;
+    this._endedAt = null;
+    this._exitReason = null;
+    this._summary = null;
+    this._chatLog = [];
+    this._segments.forEach((segment) => {
+      segment.startedAt = null;
+      segment.endedAt = null;
+      segment.elapsedMs = 0;
+      segment.status = 'pending';
+      segment._activeTimestamp = null;
+    });
+    this._currentSegmentIndex = -1;
+    this._emit('session:reset', {
+      sessionId: this.sessionId,
+      scenarioId: this.scenarioId,
+    });
+  }
+}
+
+export default SessionController;

--- a/pages/api/persistence/transcripts.js
+++ b/pages/api/persistence/transcripts.js
@@ -1,0 +1,78 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const transcriptsDir = path.join(process.cwd(), 'content', 'transcripts');
+
+async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function readJsonSafe(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeJson(filePath, data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+}
+
+export default async function handler(req, res) {
+  const userId = req.headers['x-user-id'];
+  if (!userId) {
+    return res.status(401).json({ error: 'Missing authentication context.' });
+  }
+
+  try {
+    await ensureDir(transcriptsDir);
+  } catch (error) {
+    console.error('Failed to ensure transcripts directory:', error);
+    return res.status(500).json({ error: 'Unable to initialize transcript storage.' });
+  }
+
+  const userFile = path.join(transcriptsDir, `${userId}.json`);
+
+  if (req.method === 'GET') {
+    try {
+      const data = (await readJsonSafe(userFile)) || { sessions: {} };
+      data.sessionIds = Object.keys(data.sessions || {});
+      return res.status(200).json(data);
+    } catch (error) {
+      console.error(`Failed to read transcripts for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Failed to read transcripts.' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const { sessionId, summary } = req.body ?? {};
+    if (!sessionId || !summary) {
+      return res.status(400).json({ error: 'sessionId and summary are required.' });
+    }
+
+    try {
+      const existing = (await readJsonSafe(userFile)) || { sessions: {} };
+      const timestamp = new Date().toISOString();
+      const entry = {
+        sessionId,
+        updatedAt: timestamp,
+        summary,
+      };
+      existing.sessions[sessionId] = entry;
+      existing.lastUpdated = timestamp;
+      await writeJson(userFile, existing);
+      return res.status(200).json({ ok: true, session: entry });
+    } catch (error) {
+      console.error(`Failed to persist transcript for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Failed to persist transcript.' });
+    }
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/scenarios/[id].js
+++ b/pages/api/scenarios/[id].js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { findScenarioById } from '../../../../lib/scenarios';
+import { findScenarioById } from '../../../lib/scenarios';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {

--- a/pages/api/scenarios/index.js
+++ b/pages/api/scenarios/index.js
@@ -1,4 +1,4 @@
-import { loadScenarioManifest, getDefaultScenario } from '../../../../lib/scenarios';
+import { loadScenarioManifest, getDefaultScenario } from '../../../lib/scenarios';
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {

--- a/pages/session/index.js
+++ b/pages/session/index.js
@@ -1,0 +1,345 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Head from 'next/head';
+import SummaryScreen from '../../components/session/SummaryScreen';
+import { SessionController } from '../../lib/session/controller';
+
+const SEGMENT_LABELS = [
+  'Warm-up & Goals',
+  'System Design Planning',
+  'Deep Dive & Data Flows',
+  'Trade-offs & Scaling',
+  'Wrap-up & Coaching',
+];
+
+export default function SessionRunnerPage() {
+  const [scenarios, setScenarios] = useState([]);
+  const [activeScenario, setActiveScenario] = useState(null);
+  const [status, setStatus] = useState('loading'); // loading | idle | running | summary
+  const [currentSegment, setCurrentSegment] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [draftMessage, setDraftMessage] = useState('');
+  const [summary, setSummary] = useState(null);
+  const [error, setError] = useState(null);
+  const [isPersisting, setIsPersisting] = useState(false);
+  const controllerRef = useRef(null);
+  const [user] = useState({ id: 'demo-user', name: 'Demo Candidate' });
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadScenarios = async () => {
+      try {
+        setStatus('loading');
+        const response = await fetch('/api/scenarios');
+        if (!response.ok) {
+          throw new Error('Failed to load scenarios.');
+        }
+        const data = await response.json();
+        if (!isMounted) return;
+        setScenarios(data.scenarios || []);
+        setActiveScenario(data.defaultScenario || data.scenarios?.[0] || null);
+        setStatus('idle');
+      } catch (err) {
+        console.error('Failed to fetch scenarios', err);
+        if (isMounted) {
+          setError('Unable to load scenarios. Please try again later.');
+          setStatus('idle');
+        }
+      }
+    };
+    loadScenarios();
+    return () => {
+      isMounted = false;
+      controllerRef.current?.removeAllListeners();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  const segments = useMemo(() => {
+    if (!activeScenario?.segmentDurations?.length) return [];
+    return activeScenario.segmentDurations.map((durationSeconds, index) => ({
+      id: `${activeScenario.id}-segment-${index + 1}`,
+      name: SEGMENT_LABELS[index] || `Segment ${index + 1}`,
+      durationSeconds,
+    }));
+  }, [activeScenario]);
+
+  const startSession = () => {
+    if (!activeScenario) return;
+    controllerRef.current?.removeAllListeners();
+
+    const controller = new SessionController({
+      sessionId: `${activeScenario.id}-${Date.now()}`,
+      scenarioId: activeScenario.id,
+      segments,
+      metadata: {
+        scenarioLabel: `${activeScenario.companyLabel ?? ''} ${activeScenario.topicLabel ?? ''}`.trim(),
+      },
+    });
+
+    controller.on('segment:start', ({ segment }) => {
+      setCurrentSegment(segment);
+    });
+
+    controller.on('segment:end', ({ segment }) => {
+      setCurrentSegment((current) => (current?.id === segment.id ? null : current));
+    });
+
+    controller.on('chat:message', ({ message }) => {
+      setMessages((prev) => [...prev, message]);
+    });
+
+    controller.on('summary', (payload) => {
+      setSummary(payload);
+      setStatus('summary');
+      persistSummary(payload);
+    });
+
+    controller.begin();
+    controller.advance();
+
+    controllerRef.current = controller;
+    setMessages([]);
+    setDraftMessage('');
+    setSummary(null);
+    setStatus('running');
+    setError(null);
+  };
+
+  const persistSummary = async (payload) => {
+    try {
+      setIsPersisting(true);
+      const response = await fetch('/api/persistence/transcripts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ sessionId: payload.sessionId, summary: payload }),
+      });
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(errorBody.error || 'Failed to persist transcript');
+      }
+      await response.json();
+      setError(null);
+    } catch (err) {
+      console.error('Failed to persist session summary', err);
+      setError(err.message || 'Unable to save transcript.');
+    } finally {
+      setIsPersisting(false);
+    }
+  };
+
+  const addMessage = (role) => {
+    const controller = controllerRef.current;
+    if (!controller || !draftMessage.trim()) return;
+    controller.recordMessage({ role, content: draftMessage.trim() });
+    setDraftMessage('');
+  };
+
+  const handleCompleteSegment = () => {
+    const controller = controllerRef.current;
+    if (!controller) return;
+    controller.completeCurrentSegment();
+  };
+
+  const handleExitEarly = () => {
+    const controller = controllerRef.current;
+    if (!controller) return;
+    controller.exitEarly('candidate-ended');
+  };
+
+  const resetSession = () => {
+    controllerRef.current?.reset();
+    controllerRef.current?.removeAllListeners();
+    controllerRef.current = null;
+    setStatus('idle');
+    setSummary(null);
+    setMessages([]);
+    setCurrentSegment(null);
+    setDraftMessage('');
+    setError(null);
+  };
+
+  const changeScenario = (scenarioId) => {
+    const scenario = scenarios.find((item) => item.id === scenarioId) || null;
+    setActiveScenario(scenario);
+    resetSession();
+  };
+
+  const showSummary = status === 'summary' && summary;
+
+  return (
+    <>
+      <Head>
+        <title>Session Runner</title>
+      </Head>
+      <main className="min-h-screen bg-gradient-to-b from-purple-100 via-white to-white py-10">
+        <div className="max-w-5xl mx-auto px-4 space-y-8">
+          <header className="flex flex-col gap-2">
+            <p className="text-sm uppercase tracking-wide text-purple-600 font-semibold">Interview session</p>
+            <h1 className="text-3xl font-bold text-gray-900">Run a mock ML system design interview</h1>
+            <p className="text-gray-600 max-w-2xl">
+              Progress through the timed segments, capture highlights, and review the transcript once you wrap up. You can restart
+              the session or switch scenarios at any time.
+            </p>
+          </header>
+
+          {error && status !== 'summary' && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700 text-sm">{error}</div>
+          )}
+
+          <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-6">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-900">Scenario</h2>
+                <p className="text-gray-600 text-sm">Choose a scenario to tailor prompts and coaching.</p>
+              </div>
+              <select
+                value={activeScenario?.id || ''}
+                onChange={(event) => changeScenario(event.target.value)}
+                className="w-full md:w-64 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                disabled={status === 'loading'}
+              >
+                <option value="" disabled>
+                  {status === 'loading' ? 'Loading scenarios…' : 'Select scenario'}
+                </option>
+                {scenarios.map((scenario) => (
+                  <option key={scenario.id} value={scenario.id}>
+                    {scenario.companyLabel} · {scenario.topicLabel}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {segments.length > 0 && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {segments.map((segment, index) => (
+                  <div
+                    key={segment.id}
+                    className={`rounded-xl border p-4 ${
+                      currentSegment?.id === segment.id
+                        ? 'border-purple-400 bg-purple-50'
+                        : 'border-gray-200 bg-gray-50'
+                    }`}
+                  >
+                    <div className="text-xs uppercase tracking-wide text-gray-500">Segment {index + 1}</div>
+                    <div className="mt-1 text-lg font-semibold text-gray-900">{segment.name}</div>
+                    <div className="mt-2 text-sm text-gray-600">Planned duration: {Math.round(segment.durationSeconds / 60)} min</div>
+                    {currentSegment?.id === segment.id && (
+                      <div className="mt-3 inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-700">
+                        In progress
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={startSession}
+                disabled={!activeScenario || status === 'running'}
+                className="px-4 py-2 rounded-lg bg-purple-600 text-white text-sm font-semibold shadow hover:bg-purple-700 disabled:bg-purple-300 disabled:cursor-not-allowed"
+              >
+                {status === 'running' ? 'Session in progress' : 'Start session'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCompleteSegment}
+                disabled={status !== 'running'}
+                className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed"
+              >
+                Complete segment
+              </button>
+              <button
+                type="button"
+                onClick={handleExitEarly}
+                disabled={status !== 'running'}
+                className="px-4 py-2 rounded-lg border border-red-300 text-sm font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed"
+              >
+                Exit early
+              </button>
+              <button
+                type="button"
+                onClick={resetSession}
+                className="px-4 py-2 rounded-lg border border-gray-200 text-sm text-gray-600 hover:bg-gray-100"
+              >
+                Reset
+              </button>
+            </div>
+          </section>
+
+          {status === 'running' && (
+            <section className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-4">
+              <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                <div>
+                  <h2 className="text-xl font-semibold text-gray-900">Transcript capture</h2>
+                  <p className="text-gray-600 text-sm">Log interviewer or candidate notes as you progress.</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => addMessage('candidate')}
+                    className="px-3 py-2 rounded-lg bg-purple-600 text-white text-sm font-semibold hover:bg-purple-700"
+                  >
+                    Add candidate note
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => addMessage('coach')}
+                    className="px-3 py-2 rounded-lg border border-gray-200 text-sm text-gray-700 hover:bg-gray-100"
+                  >
+                    Add coach note
+                  </button>
+                </div>
+              </div>
+
+              <textarea
+                value={draftMessage}
+                onChange={(event) => setDraftMessage(event.target.value)}
+                rows={4}
+                placeholder="Capture highlights, follow-up prompts, or coaching feedback…"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+
+              <div className="space-y-3 max-h-80 overflow-y-auto">
+                {messages.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-500">
+                    No transcript entries yet. Add candidate or coach notes to build your session log.
+                  </div>
+                ) : (
+                  messages.map((message) => (
+                    <div key={message.id} className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                      <div className="flex items-center justify-between text-xs text-gray-500">
+                        <span className="uppercase tracking-wide font-semibold text-gray-600">{message.role}</span>
+                        <span>{message.timestamp ? new Date(message.timestamp).toLocaleTimeString() : '—'}</span>
+                      </div>
+                      <p className="mt-2 text-sm text-gray-800 whitespace-pre-wrap">{message.content}</p>
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+          )}
+
+          {showSummary && (
+            <SummaryScreen
+              summary={summary}
+              onRestart={() => {
+                resetSession();
+                startSession();
+              }}
+              onChangeScenario={() => {
+                resetSession();
+              }}
+              isPersisting={isPersisting}
+              persistenceError={error && status === 'summary' ? error : null}
+            />
+          )}
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- build a reusable SessionController that captures chat logs, segment timing, and emits a wrap-up summary when a session completes or exits
- add a dedicated session runner page with a SummaryScreen component for reviewing results, downloading transcripts, and restarting flows
- persist session summaries to the authenticated user's workspace through a new transcripts API endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6ca2be8bc8327b79c61feca4cc98c