### PR TITLE
Connect home page to scenario manifest

### DIFF
--- a/content/scenarios.json
+++ b/content/scenarios.json
@@ -2,11 +2,51 @@
   "scenarios": [
     {
       "id": "meta-news-feed",
+      "title": "Meta News Feed Ranking System",
+      "description": "Design the end-to-end ranking system that powers the News Feed experience for billions of daily users while balancing engagement, well-being, and system resilience.",
+      "company": "Meta",
+      "topic": "News Feed",
+      "difficulty": "Intermediate",
+      "duration": "45 minute live interview",
+      "focusAreas": [
+        "Signals & personalization strategy",
+        "Ranking pipeline and system topology",
+        "Online metrics, guardrails, and iteration loops"
+      ],
+      "takeaways": [
+        "Clarify the product objective and define north-star metrics up front.",
+        "Translate product requirements into ML signals, features, and feedback loops.",
+        "Outline how the ranking service scales globally and adapts to real-time events."
+      ],
       "companyLabel": "Meta",
       "topicLabel": "News Feed",
-      "promptPath": "content/Meta/News-Feed/Design-a-News-Feed-ML-Ranking-System.md",
+      "promptPath": "prompts/scenarios/meta-news-feed.md",
       "segmentDurations": [600, 900, 900, 600, 600],
       "default": true
+    },
+    {
+      "id": "meta-cold-start",
+      "title": "Meta Cold Start & Onboarding",
+      "description": "You are responsible for the experience of brand new users who open the app with no historical signals. Design a bootstrapping strategy that surfaces high-quality content quickly.",
+      "company": "Meta",
+      "topic": "News Feed",
+      "difficulty": "Advanced",
+      "duration": "60 minute whiteboard",
+      "focusAreas": [
+        "User modeling without historical signals",
+        "Freshness-aware ranking and exploration",
+        "Success metrics for retention and trust"
+      ],
+      "takeaways": [
+        "Balance exploration and exploitation to learn user preferences safely.",
+        "Integrate qualitative onboarding cues with quantitative ranking feedback.",
+        "Plan measurement that isolates the impact of onboarding changes."
+      ],
+      "companyLabel": "Meta",
+      "topicLabel": "News Feed",
+      "promptPath": "prompts/scenarios/meta-cold-start.md",
+      "segmentDurations": [600, 900, 900, 600, 600],
+      "default": false
     }
   ]
 }

--- a/prompts/scenarios/meta-cold-start.md
+++ b/prompts/scenarios/meta-cold-start.md
@@ -1,0 +1,17 @@
+# Meta Cold Start & Onboarding
+
+## Product backdrop
+The first hour a user spends in the Meta app sets the tone for long-term retention. Your charter is to create an onboarding experience that keeps new users engaged even when the graph has minimal signal.
+
+## Interview brief
+Design the systems and policies that personalize the feed when the candidate has no history. Focus on how you bootstrap signal, gather explicit preferences, and ensure quality content within minutes of sign-up.
+
+## Topics to address
+- User understanding with minimal behavioral data
+- On-device heuristics, social graph seeding, and exploration tactics
+- Progressive profiling flows that inform ranking quickly
+- Cold-start model architectures and multi-armed bandit strategies
+- Measuring success and mitigating negative experiences or spam
+
+## Deliverable
+Lay out a phased plan that covers immediate onboarding, day-one retention, and week-one personalization. Call out the feedback loops that will improve the experience over time.

--- a/prompts/scenarios/meta-news-feed.md
+++ b/prompts/scenarios/meta-news-feed.md
@@ -1,0 +1,17 @@
+# Meta News Feed Ranking System
+
+## Product backdrop
+Meta's News Feed seeks to balance meaningful social interactions, user well-being, and long-term retention. Your team is responsible for the machine learning system that selects and orders stories for billions of users across surfaces.
+
+## Interview brief
+Explain how you would design the end-to-end ranking pipeline. Highlight how product objectives map to measurable success metrics, how you capture and fuse signals, and how the model architecture adapts to real-time events.
+
+## Topics to address
+- Key user segments, objectives, and engagement guardrails
+- Logging, feature stores, and feedback loops that keep data fresh
+- Ranking architecture, candidate generation, and re-ranking stages
+- Online evaluation strategies and experiment design for launches
+- Safety considerations: misinformation, integrity, and well-being
+
+## Deliverable
+Walk through the lifecycle from request to response. Include diagrams or ordered lists for important flows, and conclude with the levers you would monitor post-launch.


### PR DESCRIPTION
## Summary
- load the home page scenario list from `/api/scenarios`, add loading and retry handling, and render fetched prompt markdown
- enrich `content/scenarios.json` with full metadata for each scenario and wire in new markdown prompt sources
- author markdown prompt files for the Meta News Feed and Cold Start scenarios used by the manifest

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d32b4b788327a8b040083a822314